### PR TITLE
Refactor

### DIFF
--- a/modules/bgjob.zsh
+++ b/modules/bgjob.zsh
@@ -1,5 +1,8 @@
 #!/usr/bin/env zsh
 
 am_bg_count() {
-  echo -ne "%F{$am_fade_color}$(plib_bg_count)%f"
+  BG_COUNT=$(plib_bg_count)
+  if [[ "$BG_COUNT" -gt 0 ]]; then
+    echo -ne "%F{$am_fade_color}[$BG_COUNT]%f"
+  fi
 }

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -45,7 +45,21 @@ am_git_dirty(){
 }
 
 am_git_left_right(){
-  echo -ne "%F{$am_left_right_color}$(plib_git_left_right)%f"
+  [[ -z "${PLIB_GIT_PUSH_SYM}" ]] && PLIB_GIT_PUSH_SYM='↑'
+  [[ -z "${PLIB_GIT_PULL_SYM}" ]] && PLIB_GIT_PULL_SYM='↓'
+
+  __git_left_right=$(plib_git_left_right)
+
+  __pull=$(echo "$__git_left_right" | awk '{print $2}' | tr -d ' \n')
+  __push=$(echo "$__git_left_right" | awk '{print $1}' | tr -d ' \n')
+
+  [[ "$__pull" != 0 ]] && [[ "$__pull" != '' ]] && __pushpull="${__pull}${PLIB_GIT_PULL_SYM}"
+  [[ -n "$__pushpull" ]] && __pushpull+=' '
+  [[ "$__push" != 0 ]] && [[ "$__push" != '' ]] && __pushpull+="${__push}${PLIB_GIT_PUSH_SYM}"
+
+  if [[ "$__pushpull" != '' ]]; then
+    echo -ne "%F{$am_left_right_color}${__pushpull}%f"
+  fi
 }
 
 am_git_stash(){

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -13,7 +13,35 @@ am_git_rev(){
 }
 
 am_git_dirty(){
-  echo -ne "$(plib_git_dirty)"
+  [[ -z "${PLIB_GIT_TRACKED_COLOR}" ]] && PLIB_GIT_TRACKED_COLOR=green
+  [[ -z "${PLIB_GIT_UNTRACKED_COLOR}" ]] && PLIB_GIT_UNTRACKED_COLOR=red
+
+  [[ -z "${PLIB_GIT_ADD_SYM}" ]] && PLIB_GIT_ADD_SYM=+
+  [[ -z "${PLIB_GIT_DEL_SYM}" ]] && PLIB_GIT_DEL_SYM=-
+  [[ -z "${PLIB_GIT_MOD_SYM}" ]] && PLIB_GIT_MOD_SYM=⭑
+  [[ -z "${PLIB_GIT_NEW_SYM}" ]] && PLIB_GIT_NEW_SYM=?
+
+  __git_status=$(plib_git_status)
+
+  __mod_t=$(plib_git_staged_mod "$__git_status")
+  __add_t=$(plib_git_staged_add "$__git_status")
+  __del_t=$(plib_git_staged_del "$__git_status")
+  
+  __mod_ut=$(plib_git_unstaged_mod "$__git_status")
+  __add_ut=$(plib_git_unstaged_add "$__git_status")
+  __del_ut=$(plib_git_unstaged_del "$__git_status")
+  
+  __new=$(plib_git_status_new "$__git_status")
+
+  [[ "$__add_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
+  [[ "$__add_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
+  [[ "$__mod_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
+  [[ "$__mod_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
+  [[ "$__del_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
+  [[ "$__del_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
+  [[ "$__new" != "0" ]]    && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_NEW_SYM}%f"
+
+  unset __mod_ut __new_ut __add_ut __mod_t __new_t __add_t __del
 }
 
 am_git_left_right(){

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -33,15 +33,19 @@ am_git_dirty(){
   
   __new=$(plib_git_status_new "$__git_status")
 
-  [[ "$__add_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
-  [[ "$__add_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
-  [[ "$__mod_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
-  [[ "$__mod_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
-  [[ "$__del_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
-  [[ "$__del_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
-  [[ "$__new" != "0" ]]    && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_NEW_SYM}%f"
+  DIRTY=''
+  [[ "$__add_t" != "0" ]]  && DIRTY+="%F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f "
+  [[ "$__add_ut" != "0" ]] && DIRTY+="%F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f "
+  [[ "$__mod_t" != "0" ]]  && DIRTY+="%F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f "
+  [[ "$__mod_ut" != "0" ]] && DIRTY+="%F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f "
+  [[ "$__del_t" != "0" ]]  && DIRTY+="%F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f "
+  [[ "$__del_ut" != "0" ]] && DIRTY+="%F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f "
+  [[ "$__new" != "0" ]]    && DIRTY+="%F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_NEW_SYM}%f "
 
-  unset __mod_ut __new_ut __add_ut __mod_t __new_t __add_t __del
+  # Echo the git dirty section without the trailing space.
+  echo "${DIRTY%?}"
+
+  unset __mod_ut __new_ut __add_ut __mod_t __new_t __add_t __del DIRTY
 }
 
 am_git_left_right(){
@@ -64,11 +68,11 @@ am_git_left_right(){
 
 am_git_stash(){
   if [[ "$(plib_git_is_bare)" == 1 ]]; then
-    echo -ne " %F{$am_bare_color}${AM_GIT_BARE_SYM}${__stash}%f"
+    echo -ne "%F{$am_bare_color}${AM_GIT_BARE_SYM}${__stash}%f"
   else
     __stash=$(plib_git_stash)
     if [[ "$__stash" != "0" ]]; then
-      echo -ne " %F{$am_stash_color}${AM_GIT_STASH_SYM}${__stash}%f"
+      echo -ne "%F{$am_stash_color}${AM_GIT_STASH_SYM}${__stash}%f"
     fi
   fi
 }
@@ -79,6 +83,6 @@ am_git_commit_time(){
 
 am_git_rebasing(){
   if [[ $(plib_is_git_rebasing) == 1 ]]; then
-    echo -ne "%F{$am_error_color}${AM_GIT_REBASING_SYMBOL} %f"
+    echo -ne "%F{$am_error_color}${AM_GIT_REBASING_SYMBOL}%f"
   fi
 }

--- a/modules/init.zsh
+++ b/modules/init.zsh
@@ -34,7 +34,7 @@ fi
 [[ -z "${AM_SVN_SYM}" ]]     && AM_SVN_SYM='S'
 [[ -z "${AM_SSH_SYM}" ]]     && AM_SSH_SYM='[S]'
 
-[[ -z "${AM_GIT_REBASING_SYMBOL}" ]] && AM_GIT_REBASING_SYMBOL='⇋ '
+[[ -z "${AM_GIT_REBASING_SYMBOL}" ]] && AM_GIT_REBASING_SYMBOL='⇋'
 
 [[ -z "${PLIB_GIT_PUSH_SYM}" ]] && PLIB_GIT_PUSH_SYM='↑'
 [[ -z "${PLIB_GIT_PULL_SYM}" ]] && PLIB_GIT_PULL_SYM='↓'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Docs have been added / updated in README.md (for features)


This PR reintroduces the formating removed from plib. See [this issue](https://github.com/eendroroy/alien-minimal/issues/18) for more information on the changes.

The behavior should be totally unchanged.
There should not be any breaking change.

This MR is meant to be merged at the same time as the [associated plib MR](https://github.com/eendroroy/promptlib-zsh/pull/4) which removes the formatting from plib. Merging only one of the two would definitely break the project.

## Testing

To test the new code (with the zgen package manager, if you use something else: find the place packages are stored with your own package manager):
clone this version of alien-minimal
clone its [associated version of promptlib](https://github.com/eendroroy/promptlib-zsh/pull/4).

```
# Symlink your current prompt code to this PR's code.
cd ~/.zgen/eendroroy
mv alien-minimal-master alien-minimal-master-backup
ln -s path/to/alien-minimal-to-be-tested alien-minimal-master

# Symlink this PR's promptlib to the new version.
cd path/to/alien-minimal-to-be-tested/libs
rm -r promptlib
ln -s path/to/promptlib-to-be-tested
```

Open a new terminal and, ideally, the prompt should be unchanged.

To go back to your initial config just:
```
cd ~/.zgen/eendroroy
rm -r alien-minimal-master
mv alien-minimal-master-backup alien-minimal-master
```