### PR TITLE
Do not load the module that has already been deleted.

### DIFF
--- a/alien-minimal.zsh
+++ b/alien-minimal.zsh
@@ -17,7 +17,6 @@ source "${THEME_ROOT}/modules/git.zsh"
 source "${THEME_ROOT}/modules/hg.zsh"
 source "${THEME_ROOT}/modules/svn.zsh"
 source "${THEME_ROOT}/modules/ssh.zsh"
-source "${THEME_ROOT}/modules/bgjob.zsh"
 source "${THEME_ROOT}/modules/async.zsh"
 source "${THEME_ROOT}/modules/versions.zsh"
 


### PR DESCRIPTION
bgjob.zsh has already been deleted. Loading a file, that is not exists, throws `~/.oh-my-zsh/custom/themes/alien-minimal/alien-minimal.zsh-theme:source:20: no such file or directory: ~/.oh-my-zsh/custom/themes/alien-minimal/modules/bgjob.zsh` error.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated in README.md (for features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Simple, but a major bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Throws `~/.oh-my-zsh/custom/themes/alien-minimal/alien-minimal.zsh-theme:source:20: no such file or directory: ~/.oh-my-zsh/custom/themes/alien-minimal/modules/bgjob.zsh` error while cloning from `master`.


* **What is the new behavior (if this is a feature change)?**
Behaves just like being expected without the error.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their configuration due to this PR?)
Depends on this commit: https://github.com/eendroroy/alien-minimal/commit/31c6fb78ec5df1478a86e4c09b379ba36c73dd7c#diff-7bbe56de9317622a21897307620148c9


* **Other information**:
Nope, thanks.